### PR TITLE
Fixed a bug in the naming of RTMP_PUSH type inputs. 

### DIFF
--- a/deployment/custom_resources/custom-resource-py/lib/medialive.py
+++ b/deployment/custom_resources/custom-resource-py/lib/medialive.py
@@ -37,10 +37,10 @@ def create_push_input(config):
     if config['Type'] == 'RTMP_PUSH':
         Destination = [
             {
-                'StreamName': config['StreamName']+'primary'
+                'StreamName': config['StreamName']+'/primary'
             },
             {
-                'StreamName': config['StreamName']+'secondary'
+                'StreamName': config['StreamName']+'/secondary'
             }
         ]
     else:


### PR DESCRIPTION
*Issue #, if available:*
The previous code was creating input destinations with application names with the format `X.X.X.X1935/StreamNameprimary ` and `X.X.X.X1935/StreamNamesecondary` (were X.X.X.X is the input IP address) instead of `StreamName/primary` and `StreamName/secondary`.

*Description of changes:*
I changed the medialive.py so that it creates RTMP_PUSH inputs as 
`StreamName/primary` and `StreamName/secondary`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
