### PR TITLE
Fixed issue in Medialive RTMP_PUSH stream name

### DIFF
--- a/deployment/custom_resources/custom-resource-py/lib/medialive.py
+++ b/deployment/custom_resources/custom-resource-py/lib/medialive.py
@@ -37,10 +37,10 @@ def create_push_input(config):
     if config['Type'] == 'RTMP_PUSH':
         Destination = [
             {
-                'StreamName': config['StreamName']+'primary'
+                'StreamName': config['StreamName']+'/primary'
             },
             {
-                'StreamName': config['StreamName']+'secondary'
+                'StreamName': config['StreamName']+'/secondary'
             }
         ]
     else:


### PR DESCRIPTION
*Issue #, if available:*
According to the documentation for RTMP_PUSH the two MediaLive input channels should be of format:
rtmp://<ip address 1>:1935/streamname/primary
rtmp://<ip address 2>:1935/streamname/secondary

*Description of changes:*
I inserted a "/" between the stream name and input name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
