### PR TITLE
Fix description for MediaLiveSecondaryEndpoint

### DIFF
--- a/deployment/live-streaming-with-automated-multi-language-subtitling.template
+++ b/deployment/live-streaming-with-automated-multi-language-subtitling.template
@@ -779,7 +779,7 @@ Outputs:
     Value: !GetAtt MediaLiveInput.EndPoint1
 
   MediaLiveSecondaryEndpoint:
-    Description: Primary MediaLive input Url
+    Description: Secondary MediaLive input Url
     Value: !GetAtt MediaLiveInput.EndPoint2
 
   MediaPackageHlsEnpoint:


### PR DESCRIPTION
```diff
-    Description: Primary MediaLive input Url
+    Description: Secondary MediaLive input Url
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
