### PR TITLE
Fix duplicate key in the CloudFormation template

### DIFF
--- a/deployment/live-streaming-with-automated-multi-language-subtitling.template
+++ b/deployment/live-streaming-with-automated-multi-language-subtitling.template
@@ -410,8 +410,9 @@ Resources:
       SecMediaConnectArn: !Ref SecMediaConnectArn
 
   MediaLiveChannel:
-    DependsOn: MediaLiveInput
-    DependsOn: MediaPackageChannel
+    DependsOn:
+      - MediaLiveInput
+      - MediaPackageChannel
     Type: Custom::MediaLiveChannel
     Properties:
       ServiceToken: !GetAtt CustomResource.Arn

--- a/deployment/live-streaming-with-automated-multi-language-subtitling.template
+++ b/deployment/live-streaming-with-automated-multi-language-subtitling.template
@@ -10,9 +10,8 @@ Parameters:
       - Python-3.8
       - Nodejs12.x
 
-
   UseCloudFront:
-    Description: Deployed a CloudFront CDN Distribution in front of MediaPackage.
+    Description: Deploy a CloudFront CDN Distribution in front of MediaPackage.
     Type: String
     Default: Yes
     AllowedValues:


### PR DESCRIPTION
I replaced a duplicate `DependsOn` key for `MediaLiveChannel` resource with a list and modified `Description` for `UseCloudfront` parameter to use the imperative form.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
